### PR TITLE
changes to enable workshop reuse assets from this repo 

### DIFF
--- a/samples/multi-tenant-vector-database/amazon-opensearch/cfn/opensearch-template.yaml
+++ b/samples/multi-tenant-vector-database/amazon-opensearch/cfn/opensearch-template.yaml
@@ -47,6 +47,19 @@ Parameters:
     Type: String
     Default: "default-keypair"
 
+  CreateServiceLinkedRoleParameter:
+    Type: String
+    Default: "true"
+    AllowedValues:
+      - "true"
+      - "false"
+    Description: "Whether to create the OpenSearch Service Linked Role"
+
+Conditions:
+  CreateServiceLinkedRole: !Equals
+    - !Ref CreateServiceLinkedRoleParameter
+    - true
+
 Resources:
   VPC:
     Type: AWS::EC2::VPC
@@ -241,10 +254,10 @@ Resources:
           Value: !Sub ${EnvironmentName}-security-group
 
   # Secrets Manager Secret
-  OpenSearchMasterUserSecret:
+  OpenSearchAdminUserSecret:
     Type: AWS::SecretsManager::Secret
     Properties:
-      Name: !Sub ${EnvironmentName}-opensearch-master-user
+      Name: OpenSearchAdminUserSecret
       Description: "OpenSearch master user credentials"
       GenerateSecretString:
         SecretStringTemplate: '{"username": "admin"}'
@@ -253,7 +266,7 @@ Resources:
         ExcludeCharacters: '"@/\\'
       Tags:
         - Key: Name
-          Value: !Sub ${EnvironmentName}-opensearch-secret
+          Value: OpenSearchAdminUserSecret
 
   # OpenSearch Admin Role
   OpenSearchAdminRole:
@@ -307,6 +320,13 @@ Resources:
       Roles:
         - !Ref OpenSearchAdminRole
 
+  OpenSearchServiceLinkedRole:
+    Type: AWS::IAM::ServiceLinkedRole
+    Properties:
+      AWSServiceName: es.amazonaws.com
+      Description: Service Linked Role for OpenSearch Service
+    Condition: CreateServiceLinkedRole
+
   #OpenSearch Domain
   OpenSearchDomain:
     Type: AWS::OpenSearchService::Domain
@@ -336,8 +356,8 @@ Resources:
         InternalUserDatabaseEnabled: true
         MasterUserOptions:
           #MasterUserARN: !GetAtt OpenSearchAdminRole.Arn # Used only when InternalUserDatabaseEnabled: false
-          MasterUserName: !Sub "{{resolve:secretsmanager:${OpenSearchMasterUserSecret}:SecretString:username}}"
-          MasterUserPassword: !Sub "{{resolve:secretsmanager:${OpenSearchMasterUserSecret}:SecretString:password}}"
+          MasterUserName: !Sub "{{resolve:secretsmanager:${OpenSearchAdminUserSecret}:SecretString:username}}"
+          MasterUserPassword: !Sub "{{resolve:secretsmanager:${OpenSearchAdminUserSecret}:SecretString:password}}"
       VPCOptions:
         SubnetIds:
           - !Ref PrivateSubnet1
@@ -924,32 +944,58 @@ Outputs:
   BastionHostPublicIP:
     Description: Public IP address of the Bastion Host
     Value: !GetAtt BastionHost.PublicIp
+    Export:
+      Name: BastionHostPublicIP
 
   OpenSearchDomainEndpoint:
     Description: OpenSearch domain endpoint
     Value: !GetAtt OpenSearchDomain.DomainEndpoint
     Export:
-      Name: !Sub ${AWS::StackName}-DomainEndpoint
+      Name: OpenSearchDomainEndpoint
 
   OpenSearchDashboardURL:
     Description: OpenSearch Dashboard URL
     Value: !Sub "https://${OpenSearchDomain.DomainEndpoint}/_dashboards/"
+    Export:
+      Name: OpenSearchDomainDashboardURL
 
   OpenSearchAdminRoleArn:
     Description: ARN of the OpenSearch admin role
     Value: !GetAtt OpenSearchAdminRole.Arn
+    Export:
+      Name: OpenSearchDomainAdminRoleArn
 
   OpenSearchServerlessDashboardURL:
     Value: !GetAtt Collection.DashboardEndpoint
+    Export:
+      Name: OpenSearchServerlessDashboardURL
 
   OpenSearchServerlessCollectionId:
     Description: The ID of the created collection
     Value: !Ref Collection
+    Export:
+      Name: OpenSearchServerlessCollectionId
 
   OpenSearchServerlessCollectionARN:
     Description: The ARN of the created collection
     Value: !GetAtt Collection.Arn
+    Export:
+      Name: OpenSearchServerlessCollectionArn
 
   OpenSearchServerlessCollectionEndpoint:
     Description: The endpoint of the created collection
     Value: !GetAtt Collection.CollectionEndpoint
+    Export:
+      Name: OpenSearchServerlessCollectionEndpoint
+
+  VectorStoreVPC:
+    Description: The ID of the VPC
+    Value: !Ref VPC
+    Export:
+      Name: VectorStore-VPC-ID
+
+  VectorStorePublicSubnet1:
+    Description: The ID of Public Subnet 1
+    Value: !Ref PublicSubnet1
+    Export:
+      Name: VectorStore-PublicSubnet1-ID

--- a/samples/multi-tenant-vector-database/amazon-opensearch/self-managed/opensearch_self_managed_notebook.ipynb
+++ b/samples/multi-tenant-vector-database/amazon-opensearch/self-managed/opensearch_self_managed_notebook.ipynb
@@ -108,8 +108,7 @@
    "source": [
     "warnings.filterwarnings('ignore')\n",
     "host = \"localhost\"  # Update to vpc-domain-name when running from within the VPC\n",
-    "\n",
-    "host = host.replace(\"https://\", \"\")\n",
+    "port = \"443\" # Update to local port of SSH Tunnel (eg: 9200) when running this notebook from outside of VPC\n",
     "service = 'es'\n",
     "region = os.environ.get('AWS_REGION', 'us-west-2')\n",
     "session_name = \"opensearch-admin-session\"\n",
@@ -153,7 +152,7 @@
    "outputs": [],
    "source": [
     "opensearch_client = OpenSearch(\n",
-    "    hosts=[{'host': host, 'port': 9200}],\n",
+    "    hosts=[{'host': host, 'port': port}],\n",
     "    http_auth=admin_user_auth,\n",
     "    use_ssl=True,\n",
     "    verify_certs=False,\n",
@@ -187,7 +186,7 @@
    "source": [
     "def write_to_opensearch(content, tenant_id, metadata=None):\n",
     "    path = 'surveys/_doc'\n",
-    "    url = 'https://' + host + ':9200/' + path \n",
+    "    url = 'https://' + host + ':'+port+'/' + path \n",
     "\n",
     "    document = {\n",
     "        \"content\": content,\n",
@@ -386,7 +385,7 @@
    "outputs": [],
    "source": [
     "path = '_plugins/_security/api/rolesmapping/ml_full_access'\n",
-    "url = 'https://' + host + ':9200/' + path \n",
+    "url = 'https://' + host + ':'+port+'/' + path \n",
     "\n",
     "role_arn1 = f\"arn:aws:iam::{account_id}:role/opensearch-bedrock-role\"\n",
     "role_arn2 = f\"arn:aws:iam::{account_id}:role/opensearch-admin-role\"\n",
@@ -433,7 +432,7 @@
    "outputs": [],
    "source": [
     "path = '_plugins/_ml/connectors/_create'\n",
-    "url = 'https://' + host + ':9200/' + path \n",
+    "url = 'https://' + host + ':'+port+'/' + path \n",
     "\n",
     "payload = {\n",
     "  \"name\": \"Amazon Bedrock Connector: embedding\",\n",
@@ -486,7 +485,7 @@
    "source": [
     "# Create remote model group\n",
     "path = '_plugins/_ml/model_groups/_register'\n",
-    "url = 'https://' + host + ':9200/' + path \n",
+    "url = 'https://' + host + ':'+port+'/' + path \n",
     "\n",
     "payload = {\n",
     "  \"name\": \"remote_model_group\",\n",
@@ -502,7 +501,7 @@
     "\n",
     "# Register the remote model\n",
     "path = '_plugins/_ml/models/_register'\n",
-    "url = 'https://' + host + ':9200/' + path \n",
+    "url = 'https://' + host + ':'+port+'/' + path \n",
     "\n",
     "payload = {\n",
     "    \"name\": \"Amazon Titan Embeddings\",\n",
@@ -536,7 +535,7 @@
    "outputs": [],
    "source": [
     "path = '_plugins/_ml/tasks/' + task_id\n",
-    "url = 'https://' + host + ':9200/' + path \n",
+    "url = 'https://' + host + ':'+port+'/' + path \n",
     "r = requests.get(url, auth=admin_role_auth, json=payload, headers=headers, verify=False)\n",
     "print(r.status_code)\n",
     "print(r.text)\n",
@@ -559,7 +558,7 @@
    "source": [
     "print(model_id)\n",
     "path = f'_plugins/_ml/models/{model_id}/_predict'\n",
-    "url = 'https://' + host + ':9200/' + path \n",
+    "url = 'https://' + host + ':'+port+'/' + path \n",
     "\n",
     "payload = {\n",
     "  \"parameters\": {\n",
@@ -598,7 +597,7 @@
    "outputs": [],
    "source": [
     "path = '_ingest/pipeline/bedrock_pipeline'\n",
-    "url = 'https://' + host + ':9200/' + path \n",
+    "url = 'https://' + host + ':'+port+'/' + path \n",
     "\n",
     "pipeline_config = {\n",
     "    \"description\": \"Ingestion pipeline for Bedrock model\",\n",
@@ -637,7 +636,7 @@
    "outputs": [],
    "source": [
     "path = '/surveys'\n",
-    "url = 'https://' + host + ':9200/' + path \n",
+    "url = 'https://' + host + ':'+port+'/' + path \n",
     "\n",
     "index_config = {\n",
     "  \"settings\": {\n",
@@ -713,7 +712,7 @@
    "outputs": [],
    "source": [
     "path = '/surveys/_search'\n",
-    "url = 'https://' + host + ':9200/' + path \n",
+    "url = 'https://' + host + ':'+port+'/' + path \n",
     "\n",
     "search_config = {\n",
     "  \"query\": {\n",
@@ -797,7 +796,7 @@
    "outputs": [],
    "source": [
     "path = 'surveys/_search'\n",
-    "url = 'https://' + host + ':9200/' + path \n",
+    "url = 'https://' + host + ':'+port+'/' + path \n",
     "\n",
     "search_config = {\n",
     "  \"_source\": {\n",
@@ -873,7 +872,7 @@
    "outputs": [],
    "source": [
     "path = '/surveys/_search'\n",
-    "url = 'https://' + host + ':9200/' + path \n",
+    "url = 'https://' + host + ':'+port+'/' + path \n",
     "\n",
     "search_config = {\n",
     "  \"_source\": {\n",
@@ -946,7 +945,7 @@
    "source": [
     "# Create role for tenant1\n",
     "path = '_plugins/_security/api/roles/tenant_1'\n",
-    "url = 'https://' + host + ':9200/' + path \n",
+    "url = 'https://' + host + ':'+port+'/' + path \n",
     "\n",
     "payload = {\n",
     "  \"cluster_permissions\": [\n",
@@ -969,7 +968,7 @@
     "\n",
     "# create user for tenant1\n",
     "path = '_plugins/_security/api/internalusers/tenant_1'\n",
-    "url = 'https://' + host + ':9200/' + path \n",
+    "url = 'https://' + host + ':'+port+'/' + path \n",
     "\n",
     "payload = {\n",
     "  \"password\": \"t3n4Nt1!?\",\n",
@@ -981,7 +980,7 @@
     "\n",
     "# map user to role\n",
     "path = '_plugins/_security/api/rolesmapping/tenant_1'\n",
-    "url = 'https://' + host + ':9200/' + path \n",
+    "url = 'https://' + host + ':'+port+'/' + path \n",
     "\n",
     "payload = {\n",
     "  \"users\" : [ \"tenant_1\" ]\n",


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Changes from testing the workshop. 
1. OpenSearchServiceLinkedRole - vanilla accounts needs this role to be created and used a flag to control if this role exists already
2. Renamed OpenSearchMasterSecret to OpenSearchAdminSecret
3. Added more output/export variables to be listed in the workshop studio event. 
4. Updated tunnel port to a variable and defaulted it to 443 in the opensearch_self_managed jupyter notebook. 

The updated notebook will be pulled into the homefolder of the vscode server provisioned by the workshop studio. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
